### PR TITLE
casting the $month

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -106,7 +106,7 @@ class Converter
         $z = $z - floor($j * $y + $shift1);
 
         $year = 30 * $cyc + $j;
-        $month = floor(($z + 28.5001) / 29.5);
+        $month = (int)floor(($z + 28.5001) / 29.5);
         if ($month === 13)
         {
             $month = 12;


### PR DESCRIPTION
hi , I am getting the error `Undefined offset: 12` on PHP 7.1.12 (cli) ,

and I found out its in the [Converter.php](https://github.com/GeniusTS/hijri-dates/blob/aa49f015f735f424149fc5512652cf6b36f6ff79/src/Converter.php#L110)

so , I cast the month to be integer ,, 