### PR TITLE
Fix: recalculate does not update the year

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -382,7 +382,7 @@ class Date
         $this->julianDay = $julian;
         $this->day = $hijri->day;
         $this->month = $hijri->month;
-        $this->day = $hijri->day;
+        $this->year = $hijri->year;
 
         return $this->fillValuesArray();
     }


### PR DESCRIPTION
When calling any time manipulative `set/add/sub X` method `recalculate` does not update the year, this PR fixes it